### PR TITLE
Implement week date parameter

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,11 @@
   status = 200
 
 [[redirects]]
+  from = "/:date"
+  to = "/.netlify/functions/icalHandler?date=:date"
+  status = 200
+
+[[redirects]]
   from = "/"
   to = "/.netlify/functions/icalHandler"
   status = 200

--- a/netlify/functions/icalHandler.js
+++ b/netlify/functions/icalHandler.js
@@ -1,9 +1,20 @@
 // netlify/functions/icalHandler.js
+const { format, parse, startOfWeek } = require('date-fns');
 const { generateIcal } = require('../../core/timetableToIcal');
 
-exports.handler = async () => {
+exports.handler = async (event) => {
     try {
-        const body = await generateIcal();
+        let startDate;
+        const dateParam = event.queryStringParameters && event.queryStringParameters.date;
+        if (dateParam) {
+            const parsed = parse(dateParam, 'dd-MM-yyyy', new Date());
+            if (!isNaN(parsed)) {
+                const monday = startOfWeek(parsed, { weekStartsOn: 1 });
+                startDate = format(monday, 'yyyy-MM-dd');
+            }
+        }
+
+        const body = await generateIcal(1, startDate);
         return {
             statusCode: 200,
             headers: {


### PR DESCRIPTION
## Summary
- add optional `date` parameter to `icalHandler`
- compute Monday of selected week and pass start date
- route `/:date` URLs to the Netlify function

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_686b9d8cd40083288cc65b1d61ca03f2