### PR TITLE
Add unit test for school year start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "netlify dev",
     "build": "netlify build",
-    "timetable": "node run.js"
+    "timetable": "node run.js",
+    "test": "node tests/utils.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const { getNextSchoolYearStart } = require('../core/utils');
+
+function withMockedCurrentDate(dateString, fn) {
+  const RealDate = Date;
+  global.Date = class extends RealDate {
+    constructor(...args) {
+      if (args.length === 0) {
+        return new RealDate(dateString);
+      }
+      return new RealDate(...args);
+    }
+  };
+  try {
+    fn();
+  } finally {
+    global.Date = RealDate;
+  }
+}
+
+withMockedCurrentDate('2023-06-01T00:00:00Z', () => {
+  const nextStart = getNextSchoolYearStart();
+  assert.strictEqual(nextStart.getDay(), 1, '2023 start should be a Monday');
+});
+
+withMockedCurrentDate('2024-06-01T00:00:00Z', () => {
+  const nextStart = getNextSchoolYearStart();
+  assert.strictEqual(nextStart.getDay(), 1, '2024 start should be a Monday');
+});
+
+console.log('All tests passed.');
+


### PR DESCRIPTION
## Summary
- add a test file for `getNextSchoolYearStart`
- ensure `npm test` runs the new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ba1aafa188328ba732739a4483b20