### PR TITLE
Improve domain handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ project-root/
 3. **Configure environment**
    Create a `.env` in project root:
    ```env
-   WEBUNTIS_DOMAIN=domain // e.g. `nete`
+   WEBUNTIS_DOMAIN=yourServer
+   # `nete` or `nete.webuntis.com`
    WEBUNTIS_SCHOOL=YourSchoolName
    WEBUNTIS_USERNAME=yourUsername
    WEBUNTIS_PASSWORD=yourPassword

--- a/core/domain.js
+++ b/core/domain.js
@@ -1,0 +1,31 @@
+const https = require('https');
+
+async function resolveWebUntisHost(input) {
+  if (!input) throw new Error('WEBUNTIS_DOMAIN missing');
+  let host = input.trim();
+  if (/^https?:\/\//i.test(host)) {
+    try {
+      host = new URL(host).hostname;
+    } catch (e) {
+      throw new Error('Invalid server name');
+    }
+  }
+  if (!host.endsWith('webuntis.com')) {
+    host = `${host}.webuntis.com`;
+  }
+  const testUrl = `https://${host}/WebUntis/`;
+  const options = new URL(testUrl);
+  options.method = 'HEAD';
+
+  await new Promise((resolve, reject) => {
+    const req = https.request(options, () => resolve());
+    req.on('error', reject);
+    req.end();
+  }).catch(() => {
+    throw new Error('Could not connect to WebUntis server');
+  });
+
+  return host;
+}
+
+module.exports = { resolveWebUntisHost };

--- a/core/webuntisAuth.js
+++ b/core/webuntisAuth.js
@@ -1,9 +1,11 @@
 // src/core/webuntisAuth.js
 const axios = require('axios');
+const { resolveWebUntisHost } = require('./domain');
 
 async function login(domain, school, username, password) {
       try {
-            const url = `https://${domain}.webuntis.com/WebUntis/jsonrpc.do?school=${encodeURIComponent(school)}`;
+            const host = await resolveWebUntisHost(domain);
+            const url = `https://${host}/WebUntis/jsonrpc.do?school=${encodeURIComponent(school)}`;
             const response = await axios.post(url, {
                   id: "id",
                   method: "authenticate",

--- a/core/webuntisFetch.js
+++ b/core/webuntisFetch.js
@@ -1,13 +1,15 @@
 // src/core/webuntisFetch.js
 const axios = require('axios');
 const dotenv = require('dotenv');
+const { resolveWebUntisHost } = require('./domain');
 dotenv.config();
 
 const domain = process.env.WEBUNTIS_DOMAIN;
 
 async function fetchTimetableData(sessionId, personType, personId, date) {
       try {
-            const url = `https://${domain}.webuntis.com/WebUntis/api/public/timetable/weekly/data?elementType=${personType}&elementId=${personId}&date=${date}&formatId=1`;
+            const host = await resolveWebUntisHost(domain);
+            const url = `https://${host}/WebUntis/api/public/timetable/weekly/data?elementType=${personType}&elementId=${personId}&date=${date}&formatId=1`;
             const headers = {
                   'Cookie': `JSESSIONID=${sessionId};`,
                   'User-Agent': 'Mozilla/5.0'

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "scripts": {
     "dev": "netlify dev",
     "build": "netlify build",
-    "timetable": "node run.js",
-    "test": "node tests/utils.test.js"
-    "timetable": "node cliGenerateIcal.js",
+    "test": "node tests/index.js",
     "cli": "node cliGenerateIcal.js"
   },
   "keywords": [],

--- a/tests/domain.test.js
+++ b/tests/domain.test.js
@@ -1,0 +1,24 @@
+const assert = require('assert');
+const https = require('https');
+const { resolveWebUntisHost } = require('../core/domain');
+
+async function run() {
+  const originalRequest = https.request;
+  https.request = (_opts, cb) => {
+    const res = { statusCode: 200, on: () => {} };
+    process.nextTick(() => cb(res));
+    return { on: () => {}, end: () => {} };
+  };
+  try {
+    const host1 = await resolveWebUntisHost('nete');
+    assert.strictEqual(host1, 'nete.webuntis.com');
+
+    const host2 = await resolveWebUntisHost('https://demo.webuntis.com');
+    assert.strictEqual(host2, 'demo.webuntis.com');
+    console.log('domain tests passed');
+  } finally {
+    https.request = originalRequest;
+  }
+}
+
+run();

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,2 @@
+require('./utils.test');
+require('./domain.test');


### PR DESCRIPTION
## Summary
- add domain resolution helper
- verify WebUntis server connectivity
- support full host or short name for `WEBUNTIS_DOMAIN`
- add unit test for domain resolution
- fix `package.json` test script and run both tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68872e9d87c08328a30a8fd4ee330d5a